### PR TITLE
Fix errors on start

### DIFF
--- a/Source/RoadsOfTheRim/HarmonyPatches.cs
+++ b/Source/RoadsOfTheRim/HarmonyPatches.cs
@@ -9,9 +9,6 @@ namespace RoadsOfTheRim;
 [StaticConstructorOnStartup]
 public class HarmonyPatches
 {
-    public static RoadsOfTheRimSettings settings =
-        LoadedModManager.GetMod<RoadsOfTheRim>().GetSettings<RoadsOfTheRimSettings>();
-
     static HarmonyPatches()
     {
         var harmony = new Harmony("Loconeko.Rimworld.RoadsOfTheRim");

--- a/Source/RoadsOfTheRim/RoadsOfTheRim.cs
+++ b/Source/RoadsOfTheRim/RoadsOfTheRim.cs
@@ -20,8 +20,9 @@ public class RoadsOfTheRim : Mod
     public RoadsOfTheRim(ModContentPack content) : base(content)
     {
         settings = GetSettings<RoadsOfTheRimSettings>();
-        currentVersion =
-            VersionFromManifest.GetVersionFromModMetaData(ModLister.GetActiveModWithIdentifier("Mlie.RoadsOfTheRim"));
+        ModMetaData modMetaData = ModLister.GetActiveModWithIdentifier("Mlie.RoadsOfTheRim", /* ignorePostfix= */true);
+        currentVersion = (modMetaData != null) ?
+            VersionFromManifest.GetVersionFromModMetaData(modMetaData) : null;
     }
 
 


### PR DESCRIPTION
I recently tried to use Roads of the rim on 1.4 and got some startup errors.

The first commit is to fix the static constructor error and the second commit is to improve compatibility with Mod Manager.

Please take a look.